### PR TITLE
Fix platform deps for ESP-IDF v5.0

### DIFF
--- a/src/TaskPlatformDeps.h
+++ b/src/TaskPlatformDeps.h
@@ -199,12 +199,23 @@ namespace tm_internal {
 
     typedef TimerTask* volatile TimerTaskAtomicPtr;
     typedef volatile uint32_t TmAtomicBool; // to use CAS, the bool must be 32 bits wide
+
+
+// `uxPortCompareSet` was removed in ESP-IDF v5.0
+// See https://github.com/TcMenu/TaskManagerIO/issues/59
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
     inline bool atomicSwapBool(TmAtomicBool *ptr, bool expected, bool newValue) {
         uint32_t exp32 = expected;
         uint32_t new32 = newValue;
         uxPortCompareSet(ptr, exp32, &new32);
         return new32 == expected;
     }
+#else
+    inline bool atomicSwapBool(TmAtomicBool *ptr, bool expected, bool newValue) {
+        // function added in ESP-IDF v5.0
+        return esp_cpu_compare_and_set(ptr, expected, newValue);
+    }
+#endif
 
     /**
      * Reads an atomic boolean value


### PR DESCRIPTION
The library currently cannot be compiled when using ESP-IDF v5.0+ due to a breaking API change.

The function `uxPortCompareSet` was removed, causing a missing symbol error. This fix substitutes the function with a newly added (ESP-IDF v5) equivalent in [esp_cpu.h](https://github.com/espressif/esp-idf/blob/release/v5.5/components/esp_hw_support/include/esp_cpu.h#L612)

See #59 for more info.